### PR TITLE
Fix 'username' ('admin')

### DIFF
--- a/expressionengine/language/deutsch/myaccount_lang.php
+++ b/expressionengine/language/deutsch/myaccount_lang.php
@@ -375,7 +375,7 @@ $lang = array(
 'Als Super-Admin dürfen Sie Ihre eigene Gruppenzugehörigkeit nicht ändern!',
 
 'username' => 
-'admin',
+'Benutzername',
 
 'username_change_not_allowed' => 
 'Der Administrator erlaubt keine Änderung des Usernamens.',


### PR DESCRIPTION
Fix incorrect translation of 'username'

In various forms for member login and account management, there was the string 'admin' instead.