### PR TITLE
Update addons_lang.php

### DIFF
--- a/system/user/language/deutsch/addons_lang.php
+++ b/system/user/language/deutsch/addons_lang.php
@@ -2,132 +2,192 @@
 
 $lang = array(
 
-  /* Sidebar Menu */
-  'all_addons'					=>		'Alle Add-Ons',
-  'third_party_addons'			=>		'Externe Add-Ons',
-  'show_all_addons'				=>		'Alle %d Add-Ons',
-  'manage_extensions'				=>		'Erweiterungen verwalten',
-  'manage_addon_extensions'		=>		'Externe Add-Ons verwalten',
-
-  'addon_manager'					=>		'Add-On-Verwaltung',
-  'search_addons_button'			=>		'Add-Ons durchsuchen',
-
-  'addon'							=>		'Add-On',
-  'addons'						=>		'Add-Ons',
-  'no_addon_search_results'		=>		'Keine <b>Add-Ons</b> gefunden',
-  'no_addon_extensions_search_results'	=>		'Keine <b>Add-on Extension</b> gefunden',
-
-  'requested_module_not_installed' => 'Das angefragte Modul ist nicht installiert:',
-
-  'manual'						=>		'Manual',
-  'author'						=> 		'Autor',
-  'example_usage'					=>		'Beispiel zur Benutzung',
-  'available_parameters'			=>		'Verfügbare Parameter',
-
-  'update'						=>		'Update',
-  'update_to_version'				=>		'Update auf %s',
 
 //----------------------------
-// confirm uninstall modal
+// Sidebar Menu
 //----------------------------
 
-  'confirm_uninstall' => 'Deinstallation bestätigen',
-  'confirm_uninstall_desc' => 'Sie wollen die folgenden Punkte installieren. Bitte bestätigen Sie Ihre Aktion.',
-  'btn_confirm_and_uninstall' => 'Bestätigen und Deinstallieren',
-  'btn_confirm_and_uninstall_working' => 'Deinstalliere...',
+'addon' => 'Add-On',
 
-  /* Filters */
-  'filters'						=>		'Filter',
-  'filter_by_status'				=>		'Status',
-  'developer'						=>		'Entwickler',
-  'show'							=>		'zeigen',
-  'custom_limit'					=>		'Eigenes Limit',
-  'entries'						=>		'Artikel',
+'addon_manager' => 'Add-On-Manager',
 
-  'install'						=>		'Installieren',
-  'installed'						=>		'Installiert',
-  'uninstall'						=>		'Deinstallieren',
-  'uninstalled'					=>		'Deinstalliert',
-  'needs_updates'					=>		'Update nötig',
-  'addons_installed'				=>		'Add-Ons installiert',
-  'addons_installed_desc'			=>		'Folgende(s) Add-on(s) sind installiert worden: ',
-  'addons_uninstalled'			=>		'Add-Ons deinstalliert',
-  'addons_uninstalled_desc'		=>		'Folgende Add-on(s) sind deinstalliert worden:',
-  'addons_updated'				=>		'Add-Ons aktualisiert',
-  'addons_updated_desc'			=>		'Folgende Add-on(s) sind aktualisiert worden: ',
+'addons' => 'Add-Ons',
 
-  'btn_save_settings'             =>      'Einstellungen speichern',
-  'settings_saved'			    =>		'Einstellungen gespeichert',
-  'settings_saved_desc'		    =>		'Die Einstellungen für %s sind gespeichert worden.',
+'all_addons' => 'Alle Add-Ons',
 
-// Google Maps Keys
-  'default_map'					=>		'Standard Karte',
-  'manual_override'				=>		'Manueller Eingriff',
-  'latitude'						=>		'Breitengrad',
-  'latitude_desc'					=>		'Standard-Breitengrad für dieses Feld.',
-  'longitude'						=>		'Längengrad',
-  'longitude_desc'				=>		'Standard-Längengrad für dieses Feld.',
-  'zoom'							=>		'Zoom',
-  'zoom_desc'						=>		'Standard-Zoom-Stufe für dieses Feld.',
-  'preview'						=>		'Vorschau',
-  'preview_desc'					=>		'Standard-Kartenansicht für das Feld.',
+'author' => 'Autor',
 
+'available_parameters' => 'Verfügbare Parameter',
+
+'example_usage' => 'Nutzungs-Beispiel',
+
+'manage_addon_extensions' => 'Externe Add-Ons verwalten',
+
+'manage_extensions' => 'Add-Ons verwalten',
+
+'manual' => 'Handbuch',
+
+'no_addon_extensions_search_results' => 'Keine <b>externen Add-ons</b> gefunden',
+
+'no_addon_search_results' => 'Keine <b>Add-Ons</b> gefunden',
+
+'requested_module_not_installed' => 'Das angefragte Modul ist nicht installiert:',
+
+'search_addons_button' => 'Add-ons suchen',
+
+'show_all_addons' => 'Alle %d Add-Ons',
+
+'third_party_addons' => 'Externe Add-Ons (Third Party)',
+
+'update' => 'Update',
+
+'update_to_version' => 'Update auf %s',
+
+
+//----------------------------
+// Confirm uninstall modal
+//----------------------------
+
+'btn_confirm_and_uninstall' => 'Deinstallieren',
+
+'btn_confirm_and_uninstall_working' => 'Deinstalliere jetzt...',
+
+'confirm_uninstall' => 'Add-On-Deinstallation bestätigen',
+
+'confirm_uninstall_desc' => 'Sie wollen nun eines oder mehrere Add-Ons deinstallieren. Bestätigen Sie die Aktion, indem Sie auf den Button <b>Deinstallieren</b> klicken.',
+
+
+//----------------------------
+// Filters
+//----------------------------
+
+'addons_installed' => 'Add-Ons installiert',
+
+'addons_installed_desc' => 'Folgende(s) Add-on(s) wurde installiert: ',
+
+'addons_uninstalled' => 'Add-Ons deinstalliert',
+
+'addons_uninstalled_desc' => 'Folgende(s) Add-on(s) wurde deinstalliert: ',
+
+'addons_updated' => 'Add-Ons aktualisiert',
+
+'addons_updated_desc' => 'Folgende(s) Add-on(s) wurde aktualisiert: ',
+
+'btn_save_settings' => 'Einstellungen speichern',
+
+'custom_limit' => 'Persönliches Limit',
+
+'developer' => 'developer',
+
+'entries' => 'Einträge',
+
+'extension_class_does_not_exist' => 'Add-On-Klasse %c existiert nicht in (%f)',
+
+'filter_by_status' => 'Status',
+
+'install' => 'Installieren',
+
+'installed' => 'Installiert',
+
+'needs_updates' => 'Updates benötigt',
+
+'settings_saved' => 'Einstellungen gespeichert',
+
+'settings_saved_desc' => 'Die Einstellungen für %s wurden gespeichert.',
+
+'uninstall' => 'Deinstallieren',
+
+'uninstalled' => 'Deinstalliert',
+
+
+//----------------------------
 // 2.x
+//----------------------------
 
-  'modules'						=>		'Module',
-  'extensions'					=>		'Extensions',
-  'plugins'						=>		'Plugins',
+'addons_extensions' => 'Extensions',
 
-  'module'						=>		'Module',
-  'extension'						=>		'Extension',
-  'rte_tool'						=>		'Rich Text Editor',
+'addons_fieldtypes' => 'Feldtypen',
 
-  'addons_modules'				=>		'Module',
-  'addons_plugins'				=>		'Plugins',
-  'addons_extensions'				=>		'Extensions',
-  'addons_fieldtypes'				=>		'Feldtyp',
+'addons_modules' => 'Module',
 
-  'fieldtype_name'				=>		'Feldtyp-Name',
-  'not_installed'					=>		'Nicht installiert',
-  'remove'						=>		'Entfernen',
-  'extension_enabled'				=>		'Extension installiert',
-  'extension_disabled'			=>		'Extension deinstalliert',
-  'extensions_enabled'			=>		'Extensions installiert',
-  'extensions_disabled'			=>		'Extensions deinstalliert',
-  'extensions_enabled_desc'		=>		'Extensions wurden installiert.',
-  'extensions_disabled_desc'		=>		'Extensions wurden deinstalliert.',
-  'ext_enabled_short'				=>		'installiert',
-  'ext_disabled_short'			=>		'deinstalliert',
+'addons_plugins' => 'Plugins',
 
-  'delete_fieldtype_confirm'		=>		'Wollen Sie wirklich diesen Feldtyp entfernen?',
-  'delete_fieldtype'				=>		'Feldtyp entfernen',
-  'fieldtype_data_will_be_lost'	=>		'Alle mit diesem Feldtyp verbundenen Daten, inklusive aller verknüpften Daten in den Channels, werden unwiderruflich gelöscht!',
-  'global_settings_saved'			=>		'Einstellungen gespeichert',
+'and_more' => 'und %x mehr...',
 
-  'package_settings'				=>		'Package Einstellungen',
-  'component'						=>		'Bestandteil',
-  'current_status'				=>		'Derzeitiger Status',
-  'required_by'					=>		'Benötigt von:',
-  'extensions_disabled_warning'	=>		'Um dieses Add-On zu installieren, müssen Sie Extensions aktivieren. Wollen Sie Extensions aktivieren?',
+'available_to_member_groups' => 'Verfügbar für Mitgliedergruppen',
 
-  'available_to_member_groups'	=>		'Verfügbar für diese Nutzergruppen',
-  'specific_page'					=>		'Bestimmte Seite?',
-  'description'					=>		'Beschreibung',
-  'version'						=>		'Version',
-// 'status'						=>		'Status',
-  'fieldtype'						=>		'Feldtyp',
+'component' => 'Bestandteil',
 
-  'member_group_assignment'		=>		'Zugewiesene Nutzergruppe',
-  'page_assignment'				=>		'Zugewiesene Seiten',
+'configuration' => 'Konfiguration',
 
-  'none'							=>		'Nichts',
-  'and_more'						=>		'und %x mehr...',
-  'plugins_not_available'			=> 		'Plugin-Feed ist in der Beta Version deaktiviert.',
-  'no_extension_id'				=>		'Keine Extension angegeben',
-  'configuration'					=>		'Konfiguration',
+'current_status' => 'Aktueller Status',
 
-// IGNORE
-  ''=>'');
-/* End of file addons_lang.php */
-/* Location: ./system/user/language/deutsch/addons_lang.php */
+'delete_fieldtype' => 'Feldtyp entfernen',
 
+'delete_fieldtype_confirm' => 'Wollen Sie wirklich diesen Feldtyp entfernen?',
+
+'description' => 'Beschreibung',
+
+'ext_disabled_short' => 'Untauglich',
+
+'ext_enabled_short' => 'Aktiviert',
+
+'extension' => 'Extension',
+
+'extension_disabled' => 'Extension deaktiviert',
+
+'extension_enabled' => 'Extension aktiviert',
+
+'extensions' => 'Extensions',
+
+'extensions_disabled' => 'Extensions deaktivieren',
+
+'extensions_disabled_desc' => 'Extensions wurden deaktiviert',
+
+'extensions_disabled_warning' => 'Sie müssen für die Installation dieses Add-ons die Extensions aktivieren. Möchten Sie Erweiterungen aktivieren?',
+
+'extensions_enabled' => 'Extension aktiviert',
+
+'extensions_enabled_desc' => 'Extensions wurden aktiviert.',
+
+'fieldtype' => 'Feldtyp',
+
+'fieldtype_data_will_be_lost' => 'Alle mit diesem Feldtyp verbundenen Daten, inklusive aller verknüpften Daten in den Channels, werden unwiderruflich gelöscht!',
+
+'fieldtype_name' => 'Feldname',
+
+'global_settings_saved' => 'Einstellungen gespeichert',
+
+'member_group_assignment' => 'Zugewiesene Mitgliedergruppe',
+
+'module' => 'Modul',
+
+'modules' => 'Module',
+
+'no_extension_id' => 'Keine Erweiterung angegeben',
+
+'none' => 'Keine',
+
+'not_installed' => 'Nicht installiert',
+
+'package_settings' => 'Paket-Einstellungen',
+
+'page_assignment' => 'Zugewiesene Seiten',
+
+'plugins' => 'Plugins',
+
+'plugins_not_available' => 'Plugin-Feed ist in der Beta Version deaktiviert.',
+
+'remove' => 'Entfernen',
+
+'required_by' => 'Benötigt von:',
+
+'rte_tool' => 'Rich Text Editor Tool',
+
+'specific_page' => 'Spezifische Seite?',
+
+'version' => 'Version',
+
+);
+
+// EOF


### PR DESCRIPTION
I hope, this file is ready to work for german customers ;) 

At the moment I work on the file "admin_content_lang" (it's really long ;) and I have some question about the following line:

’checkbox_options_desc' => '`<em><i>`Each item in the textarea will generate a single checkbox and label pair in the publish form.`</i>`',

- Where can I find the row in the backend?
- Is `<em>` and `<i>` neccessary or they can get away?

Thank you